### PR TITLE
Add dictionary lookup Chrome extension

### DIFF
--- a/dictionary-extension/manifest.json
+++ b/dictionary-extension/manifest.json
@@ -1,0 +1,12 @@
+{
+  "manifest_version": 3,
+  "name": "English Learner Dictionary",
+  "version": "1.0.0",
+  "description": "Look up selected English words and track encounter frequency for English learners.",
+  "permissions": ["activeTab", "scripting", "storage"],
+  "host_permissions": ["https://api.dictionaryapi.dev/*"],
+  "action": {
+    "default_title": "English Learner Dictionary",
+    "default_popup": "popup.html"
+  }
+}

--- a/dictionary-extension/popup.css
+++ b/dictionary-extension/popup.css
@@ -1,0 +1,184 @@
+:root {
+  color-scheme: light dark;
+  --accent: #2563eb;
+  --accent-soft: rgba(37, 99, 235, 0.1);
+  --bg: #0f172a;
+  --fg: #e2e8f0;
+  --border: rgba(15, 23, 42, 0.15);
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+}
+
+body {
+  margin: 0;
+  min-width: 360px;
+  max-width: 420px;
+  max-height: 520px;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(180deg, #0f172a 0%, #111827 45%, #1f2937 100%);
+  color: var(--fg);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 18px 8px;
+  background: rgba(15, 23, 42, 0.65);
+  backdrop-filter: blur(6px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.header h1 {
+  font-size: 1.2rem;
+  margin: 0;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+}
+
+.header button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: none;
+  background: var(--accent);
+  color: white;
+  padding: 8px 12px;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.35);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.header button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 22px rgba(37, 99, 235, 0.45);
+}
+
+.results {
+  padding: 0 18px 18px;
+  overflow-y: auto;
+  flex: 1 1 auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--accent) rgba(148, 163, 184, 0.2);
+}
+
+.results::-webkit-scrollbar {
+  width: 8px;
+}
+
+.results::-webkit-scrollbar-thumb {
+  background: var(--accent);
+  border-radius: 999px;
+}
+
+.placeholder {
+  font-size: 0.95rem;
+  line-height: 1.5;
+  margin-top: 80px;
+  text-align: center;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.word-card {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 18px;
+  padding: 16px;
+  margin-top: 16px;
+  box-shadow: 0 18px 30px rgba(15, 23, 42, 0.2);
+}
+
+.word-card:first-of-type {
+  margin-top: 0;
+}
+
+.word-card header {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.word-title {
+  font-size: 1.4rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.lookup-count {
+  background: rgba(37, 99, 235, 0.2);
+  color: var(--fg);
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.definition-group {
+  margin-bottom: 12px;
+}
+
+.part-of-speech {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: rgba(125, 211, 252, 0.9);
+  background: rgba(125, 211, 252, 0.15);
+  padding: 4px 8px;
+  border-radius: 999px;
+  margin-bottom: 8px;
+}
+
+.meanings-list {
+  list-style: decimal;
+  margin: 0 0 10px 18px;
+  padding: 0;
+  line-height: 1.5;
+}
+
+.meanings-list li {
+  margin-bottom: 6px;
+}
+
+.example {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.9);
+  border-left: 3px solid rgba(148, 163, 184, 0.4);
+  padding-left: 8px;
+}
+
+.synonyms {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 6px 0 0;
+}
+
+.synonym {
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(74, 222, 128, 0.18);
+  color: rgba(187, 247, 208, 0.95);
+  font-size: 0.8rem;
+}
+
+.footer {
+  padding: 8px 18px 14px;
+  font-size: 0.8rem;
+  color: rgba(226, 232, 240, 0.7);
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.status {
+  display: block;
+  min-height: 1em;
+}

--- a/dictionary-extension/popup.html
+++ b/dictionary-extension/popup.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>English Learner Dictionary</title>
+    <link rel="stylesheet" href="popup.css" />
+  </head>
+  <body>
+    <header class="header">
+      <h1>Word Insight</h1>
+      <button id="open-stats" title="View lookup rankings">
+        <span class="icon">📊</span>
+        Rankings
+      </button>
+    </header>
+    <main id="results" class="results">
+      <div class="placeholder">
+        Select a word on the current tab and then open the extension to see its meaning.
+      </div>
+    </main>
+    <footer class="footer">
+      <span class="status" id="status"></span>
+    </footer>
+    <script src="popup.js" type="module"></script>
+  </body>
+</html>

--- a/dictionary-extension/popup.js
+++ b/dictionary-extension/popup.js
@@ -1,0 +1,145 @@
+const resultsEl = document.getElementById("results");
+const statusEl = document.getElementById("status");
+const statsBtn = document.getElementById("open-stats");
+
+statsBtn.addEventListener("click", async () => {
+  const url = chrome.runtime.getURL("stats.html");
+  await chrome.tabs.create({ url });
+});
+
+document.addEventListener("DOMContentLoaded", async () => {
+  statusEl.textContent = "Fetching selected text...";
+  const word = await getSelectedWord();
+
+  if (!word) {
+    renderPlaceholder(
+      "No word detected. Highlight a single English word and reopen the extension."
+    );
+    statusEl.textContent = "";
+    return;
+  }
+
+  statusEl.textContent = `Looking up \"${word}\"...`;
+
+  try {
+    const data = await fetchDefinition(word);
+    if (!data || !data.length) {
+      throw new Error("No definitions returned");
+    }
+
+    const lookupCount = await bumpLookupCount(word);
+    renderDefinitions(word, lookupCount, data);
+    statusEl.textContent = "Tap the Rankings button to review your most encountered words.";
+  } catch (error) {
+    console.error(error);
+    renderPlaceholder(
+      "We couldn't find a definition for that selection. Try another English word."
+    );
+    statusEl.textContent = "";
+  }
+});
+
+async function getSelectedWord() {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (!tab?.id) return "";
+
+  try {
+    const [{ result } = {}] = await chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      func: () => window.getSelection().toString().trim(),
+    });
+    return (result || "").split(/\s+/)[0]?.replace(/[^a-zA-Z\-']/g, "").toLowerCase();
+  } catch (error) {
+    console.error("Unable to retrieve selected text", error);
+    return "";
+  }
+}
+
+async function fetchDefinition(word) {
+  const response = await fetch(
+    `https://api.dictionaryapi.dev/api/v2/entries/en/${encodeURIComponent(word)}`
+  );
+  if (!response.ok) {
+    throw new Error(`Lookup failed: ${response.status}`);
+  }
+  return response.json();
+}
+
+async function bumpLookupCount(word) {
+  const { lookupCounts = {} } = await chrome.storage.local.get("lookupCounts");
+  const nextValue = (lookupCounts[word] || 0) + 1;
+  await chrome.storage.local.set({
+    lookupCounts: {
+      ...lookupCounts,
+      [word]: nextValue,
+    },
+  });
+  return nextValue;
+}
+
+function renderDefinitions(word, lookupCount, entries) {
+  resultsEl.innerHTML = "";
+
+  const card = document.createElement("section");
+  card.className = "word-card";
+
+  const header = document.createElement("header");
+  const title = document.createElement("h2");
+  title.className = "word-title";
+  title.textContent = word;
+
+  const countPill = document.createElement("span");
+  countPill.className = "lookup-count";
+  countPill.textContent = `${lookupCount} lookup${lookupCount > 1 ? "s" : ""}`;
+
+  header.append(title, countPill);
+  card.appendChild(header);
+
+  entries.forEach((entry) => {
+    entry.meanings?.forEach((meaning) => {
+      const group = document.createElement("article");
+      group.className = "definition-group";
+
+      const partOfSpeech = document.createElement("span");
+      partOfSpeech.className = "part-of-speech";
+      partOfSpeech.textContent = meaning.partOfSpeech || "Meaning";
+
+      const list = document.createElement("ol");
+      list.className = "meanings-list";
+
+      meaning.definitions?.slice(0, 5).forEach((definition) => {
+        const item = document.createElement("li");
+        item.textContent = definition.definition;
+        if (definition.example) {
+          const example = document.createElement("span");
+          example.className = "example";
+          example.textContent = `Example: ${definition.example}`;
+          item.appendChild(example);
+        }
+        list.appendChild(item);
+      });
+
+      group.append(partOfSpeech, list);
+
+      if (meaning.synonyms?.length) {
+        const synonyms = document.createElement("div");
+        synonyms.className = "synonyms";
+        meaning.synonyms.slice(0, 10).forEach((syn) => {
+          const chip = document.createElement("span");
+          chip.className = "synonym";
+          chip.textContent = syn;
+          synonyms.appendChild(chip);
+        });
+        group.appendChild(synonyms);
+      }
+
+      card.appendChild(group);
+    });
+  });
+
+  resultsEl.appendChild(card);
+}
+
+function renderPlaceholder(message) {
+  resultsEl.innerHTML = `<div class="placeholder">${message}</div>`;
+}

--- a/dictionary-extension/stats.css
+++ b/dictionary-extension/stats.css
@@ -1,0 +1,172 @@
+:root {
+  color-scheme: light dark;
+  --bg: #0f172a;
+  --fg: #e2e8f0;
+  --accent: #6366f1;
+  --accent-2: #14b8a6;
+  --muted: rgba(148, 163, 184, 0.75);
+  --card-bg: rgba(15, 23, 42, 0.7);
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #312e81 0%, #0f172a 55%, #020617 100%);
+  color: var(--fg);
+  display: flex;
+  justify-content: center;
+  padding: 48px 16px;
+}
+
+.container {
+  width: min(720px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 24px;
+  padding: 28px;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.2), rgba(20, 184, 166, 0.2));
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 28px;
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.45);
+}
+
+.hero-content h1 {
+  margin: 8px 0;
+  font-size: clamp(2rem, 4vw, 2.8rem);
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.75rem;
+  color: rgba(165, 180, 252, 0.85);
+  margin: 0;
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+  max-width: 420px;
+}
+
+.reset {
+  align-self: center;
+  padding: 10px 18px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(14, 116, 144, 0.35);
+  color: var(--fg);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.reset:hover {
+  transform: translateY(-2px);
+  background: rgba(14, 116, 144, 0.5);
+}
+
+.leaderboard {
+  display: grid;
+  gap: 16px;
+}
+
+.leaderboard.empty::before {
+  content: "You haven't looked up any words yet. Explore and come back!";
+  display: block;
+  text-align: center;
+  padding: 48px 24px;
+  border-radius: 24px;
+  background: rgba(30, 41, 59, 0.65);
+  border: 1px dashed rgba(148, 163, 184, 0.3);
+  color: var(--muted);
+}
+
+.card {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 18px;
+  align-items: center;
+  padding: 20px 24px;
+  border-radius: 24px;
+  background: var(--card-bg);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.35);
+}
+
+.medal {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-size: 1.4rem;
+  font-weight: 700;
+  background: rgba(99, 102, 241, 0.25);
+}
+
+.card:nth-child(1) .medal {
+  background: radial-gradient(circle at top, #fde68a, #fbbf24);
+  color: #78350f;
+}
+
+.card:nth-child(2) .medal {
+  background: radial-gradient(circle at top, #e5e7eb, #d1d5db);
+  color: #374151;
+}
+
+.card:nth-child(3) .medal {
+  background: radial-gradient(circle at top, #f9a8d4, #f472b6);
+  color: #831843;
+}
+
+.word-info h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.word-info p {
+  margin: 6px 0 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.count-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.25);
+  font-weight: 600;
+}
+
+.progress {
+  grid-column: 2 / span 2;
+  height: 6px;
+  background: rgba(148, 163, 184, 0.25);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress span {
+  display: block;
+  height: 100%;
+  background: linear-gradient(90deg, var(--accent), var(--accent-2));
+}
+
+.footer {
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.8rem;
+}

--- a/dictionary-extension/stats.html
+++ b/dictionary-extension/stats.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Lookup Rankings</title>
+    <link rel="stylesheet" href="stats.css" />
+  </head>
+  <body>
+    <div class="container">
+      <header class="hero">
+        <div class="hero-content">
+          <p class="eyebrow">Your Vocabulary Journey</p>
+          <h1>Encounter Rankings</h1>
+          <p class="subtitle">
+            Track how often you look up words and celebrate your growing vocabulary.
+          </p>
+        </div>
+        <button id="reset" class="reset" title="Clear ranking data">Reset stats</button>
+      </header>
+      <section id="leaderboard" class="leaderboard"></section>
+      <footer class="footer">Powered by freeDictionaryAPI.</footer>
+    </div>
+    <script src="stats.js" type="module"></script>
+  </body>
+</html>

--- a/dictionary-extension/stats.js
+++ b/dictionary-extension/stats.js
@@ -1,0 +1,70 @@
+const leaderboardEl = document.getElementById("leaderboard");
+const resetBtn = document.getElementById("reset");
+
+resetBtn.addEventListener("click", async () => {
+  const confirmed = confirm("Reset all lookup counts? This cannot be undone.");
+  if (!confirmed) return;
+  await chrome.storage.local.set({ lookupCounts: {} });
+  renderLeaderboard({});
+});
+
+(async function init() {
+  const { lookupCounts = {} } = await chrome.storage.local.get("lookupCounts");
+  renderLeaderboard(lookupCounts);
+})();
+
+function renderLeaderboard(counts) {
+  leaderboardEl.innerHTML = "";
+  const entries = Object.entries(counts)
+    .filter(([, value]) => typeof value === "number" && value > 0)
+    .sort((a, b) => b[1] - a[1]);
+
+  if (!entries.length) {
+    leaderboardEl.classList.add("empty");
+    return;
+  }
+
+  leaderboardEl.classList.remove("empty");
+
+  const topCount = entries[0][1];
+  entries.forEach(([word, count], index) => {
+    const card = document.createElement("article");
+    card.className = "card";
+
+    const medal = document.createElement("div");
+    medal.className = "medal";
+    medal.textContent = index + 1;
+
+    const info = document.createElement("div");
+    info.className = "word-info";
+
+    const title = document.createElement("h2");
+    title.textContent = word;
+
+    const subtitle = document.createElement("p");
+    subtitle.textContent = generateSubtitle(count);
+
+    info.append(title, subtitle);
+
+    const pill = document.createElement("span");
+    pill.className = "count-pill";
+    pill.textContent = `${count} encounter${count > 1 ? "s" : ""}`;
+
+    const progress = document.createElement("div");
+    progress.className = "progress";
+
+    const bar = document.createElement("span");
+    bar.style.width = `${Math.max(12, (count / topCount) * 100)}%`;
+    progress.appendChild(bar);
+
+    card.append(medal, info, pill, progress);
+    leaderboardEl.appendChild(card);
+  });
+}
+
+function generateSubtitle(count) {
+  if (count >= 15) return "You're mastering this word!";
+  if (count >= 8) return "Keep reviewing to make it stick.";
+  if (count >= 4) return "Repetition builds confidence.";
+  return "A new discovery awaits more practice.";
+}


### PR DESCRIPTION
## Summary
- add a new Chrome extension that looks up the selected English word using freeDictionaryAPI and displays formatted results in a scrollable popup
- track lookup counts in chrome.storage and provide a separate rankings tab with a styled leaderboard and reset action

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e31f922a3c832ba0eb2e6933571a16