### PR TITLE
Add X-Frame-Bypass iframe support

### DIFF
--- a/MultipleWindow/background.js
+++ b/MultipleWindow/background.js
@@ -1,0 +1,119 @@
+const dashboardTabs = new Set();
+
+const registerTab = (tabId) => {
+  if (typeof tabId === 'number') {
+    dashboardTabs.add(tabId);
+  }
+};
+
+const unregisterTab = (tabId) => {
+  if (typeof tabId === 'number') {
+    dashboardTabs.delete(tabId);
+  }
+};
+
+chrome.action.onClicked.addListener(async () => {
+  const tab = await chrome.tabs.create({
+    url: chrome.runtime.getURL('dashboard.html')
+  });
+  if (tab?.id !== undefined) {
+    registerTab(tab.id);
+  }
+});
+
+chrome.tabs.onRemoved.addListener((tabId) => {
+  unregisterTab(tabId);
+});
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (!message || typeof message !== 'object') {
+    return;
+  }
+
+  if (message.type === 'registerDashboard') {
+    const tabId =
+      typeof message.tabId === 'number'
+        ? message.tabId
+        : sender?.tab?.id ?? undefined;
+    if (tabId !== undefined) {
+      registerTab(tabId);
+    }
+    if (typeof sendResponse === 'function') {
+      sendResponse({ tabId });
+    }
+    return false;
+  }
+
+  if (message.type === 'unregisterDashboard') {
+    const tabId =
+      typeof message.tabId === 'number'
+        ? message.tabId
+        : sender?.tab?.id ?? undefined;
+    if (tabId !== undefined) {
+      unregisterTab(tabId);
+    }
+  }
+});
+
+const extractFrameBlockingReason = (responseHeaders = []) => {
+  const reasons = [];
+  let frameAncestors = null;
+
+  responseHeaders.forEach((header) => {
+    if (!header || !header.name) {
+      return;
+    }
+    const name = header.name.toLowerCase();
+    if (name === 'x-frame-options') {
+      const value = header.value ?? '';
+      reasons.push(`X-Frame-Options: ${value}`);
+      return;
+    }
+    if (name === 'content-security-policy') {
+      const value = header.value ?? '';
+      const directive = value
+        .split(';')
+        .map((part) => part.trim())
+        .find((part) => part.toLowerCase().startsWith('frame-ancestors'));
+      if (directive) {
+        frameAncestors = directive.split(/\s+/).slice(1);
+      }
+    }
+  });
+
+  if (Array.isArray(frameAncestors) && frameAncestors.length > 0) {
+    const normalized = frameAncestors.map((token) => token.toLowerCase());
+    const allowsAny = normalized.includes('*') || normalized.some((token) => token.startsWith('chrome-extension://'));
+    if (!allowsAny) {
+      reasons.push(`Content-Security-Policy: frame-ancestors ${frameAncestors.join(' ')}`);
+    }
+  }
+
+  if (reasons.length === 0) {
+    return null;
+  }
+
+  return reasons.join(' / ');
+};
+
+chrome.webRequest.onHeadersReceived.addListener(
+  (details) => {
+    if (!dashboardTabs.has(details.tabId)) {
+      return;
+    }
+
+    const reason = extractFrameBlockingReason(details.responseHeaders);
+    if (!reason) {
+      return;
+    }
+
+    chrome.runtime.sendMessage({
+      type: 'frameBlocked',
+      tabId: details.tabId,
+      url: details.url,
+      reason
+    });
+  },
+  { urls: ['<all_urls>'], types: ['sub_frame'] },
+  ['extraHeaders']
+);

--- a/MultipleWindow/dashboard.css
+++ b/MultipleWindow/dashboard.css
@@ -1,0 +1,304 @@
+:root {
+  color-scheme: light dark;
+  --bg-color: #0f172a;
+  --surface-color: #1e293b;
+  --surface-color-light: #f8fafc;
+  --text-color: #e2e8f0;
+  --text-color-light: #0f172a;
+  --accent-color: #38bdf8;
+  --border-color: rgba(148, 163, 184, 0.4);
+  --shadow: 0 10px 25px rgba(15, 23, 42, 0.15);
+  font-size: 16px;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(30, 41, 59, 0.95)), url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160"%3E%3Cg fill="none" stroke="%2338bdf8" stroke-opacity="0.12" stroke-width="1"%3E%3Cpath d="M0 0h160v160H0z"/%3E%3Cpath d="M80 0v160M0 80h160"/%3E%3C/g%3E%3C/svg%3E');
+  color: var(--text-color);
+  font-family: 'Segoe UI', 'Hiragino Kaku Gothic ProN', 'Meiryo', sans-serif;
+}
+
+.app-header {
+  padding: 1.5rem 2rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  background-color: rgba(15, 23, 42, 0.75);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.3);
+  box-shadow: var(--shadow);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.app-title {
+  margin: 0;
+  font-size: 1.75rem;
+  letter-spacing: 0.04em;
+}
+
+.add-column-form {
+  display: flex;
+  gap: 1rem;
+  align-items: end;
+  flex-wrap: wrap;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 220px;
+  color: var(--text-color);
+}
+
+.label-text {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  opacity: 0.7;
+}
+
+input[type='url'],
+input[type='number'] {
+  border-radius: 0.75rem;
+  border: 1px solid var(--border-color);
+  padding: 0.65rem 0.9rem;
+  font-size: 1rem;
+  background-color: rgba(15, 23, 42, 0.35);
+  color: var(--text-color);
+  outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input[type='url']::placeholder {
+  color: rgba(226, 232, 240, 0.5);
+}
+
+input[type='url']:focus,
+input[type='number']:focus {
+  border-color: rgba(56, 189, 248, 0.65);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.2);
+}
+
+.primary-button,
+.secondary-button,
+.icon-button {
+  border: none;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background-color 0.2s ease;
+}
+
+.primary-button {
+  background: linear-gradient(135deg, #38bdf8, #2563eb);
+  color: white;
+  padding: 0.75rem 1.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.3);
+}
+
+.primary-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 28px rgba(37, 99, 235, 0.35);
+}
+
+.secondary-button {
+  background-color: rgba(148, 163, 184, 0.18);
+  color: var(--text-color);
+  padding: 0.5rem 0.9rem;
+  border-radius: 0.75rem;
+  font-weight: 500;
+}
+
+.secondary-button:hover {
+  background-color: rgba(148, 163, 184, 0.28);
+}
+
+.icon-button {
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 50%;
+  background-color: rgba(248, 113, 113, 0.15);
+  color: #fca5a5;
+  font-size: 1.1rem;
+  display: grid;
+  place-items: center;
+}
+
+.icon-button:hover {
+  background-color: rgba(248, 113, 113, 0.25);
+  transform: scale(1.05);
+}
+
+.columns {
+  flex: 1;
+  display: flex;
+  gap: 1rem;
+  padding: 1.5rem;
+  overflow-x: auto;
+  align-items: stretch;
+}
+
+.column {
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.8), rgba(30, 41, 59, 0.9));
+  border-radius: 1rem;
+  display: flex;
+  flex-direction: column;
+  min-width: 220px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.column:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 16px 35px rgba(15, 23, 42, 0.35);
+}
+
+.column-header {
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  background-color: rgba(15, 23, 42, 0.65);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.navigation-form {
+  display: flex;
+  gap: 0.6rem;
+}
+
+.address-input {
+  flex: 1;
+  min-width: 0;
+  border-radius: 0.65rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  padding: 0.5rem 0.75rem;
+  background-color: rgba(15, 23, 42, 0.3);
+  color: var(--text-color);
+}
+
+.address-input:focus {
+  border-color: rgba(56, 189, 248, 0.6);
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.2);
+}
+
+.column-controls {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.width-control {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.width-slider {
+  width: 130px;
+}
+
+.width-value {
+  min-width: 3ch;
+  text-align: right;
+}
+
+.frame-container {
+  position: relative;
+  flex: 1;
+  display: flex;
+  min-height: 200px;
+}
+
+.column-frame {
+  flex: 1;
+  border: none;
+  background-color: white;
+}
+
+.frame-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  background: rgba(15, 23, 42, 0.82);
+  backdrop-filter: blur(6px);
+  color: var(--text-color);
+  text-align: center;
+  z-index: 2;
+}
+
+.frame-overlay.is-error {
+  background: rgba(15, 23, 42, 0.92);
+  border: 1px solid rgba(248, 113, 113, 0.35);
+}
+
+.frame-overlay[hidden] {
+  display: none;
+}
+
+.overlay-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-width: 320px;
+}
+
+.overlay-title {
+  margin: 0;
+  font-size: 1.1rem;
+  letter-spacing: 0.03em;
+}
+
+.overlay-message {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.overlay-detail {
+  margin: 0;
+  font-size: 0.8rem;
+  opacity: 0.8;
+  word-break: break-word;
+}
+
+.overlay-actions {
+  display: flex;
+  justify-content: center;
+}
+
+@media (max-width: 960px) {
+  .add-column-form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .columns {
+    flex-direction: column;
+  }
+
+  .column {
+    width: auto !important;
+  }
+}
+
+.input-error {
+  border-color: rgba(248, 113, 113, 0.8) !important;
+  box-shadow: 0 0 0 2px rgba(248, 113, 113, 0.2) !important;
+}

--- a/MultipleWindow/dashboard.html
+++ b/MultipleWindow/dashboard.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Multi Column Viewer</title>
+    <link rel="stylesheet" href="dashboard.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1 class="app-title">Multiple Window Columns</h1>
+      <form id="add-column-form" class="add-column-form">
+        <label class="form-field">
+          <span class="label-text">URL</span>
+          <input type="url" id="url-input" placeholder="https://example.com" required />
+        </label>
+        <label class="form-field">
+          <span class="label-text">幅 (%)</span>
+          <input type="number" id="width-input" min="10" max="100" value="30" />
+        </label>
+        <button type="submit" class="primary-button">列を追加</button>
+      </form>
+    </header>
+    <main id="columns" class="columns" role="list"></main>
+    <template id="column-template">
+      <section class="column" role="listitem">
+        <header class="column-header">
+          <form class="navigation-form">
+            <input type="url" class="address-input" required />
+            <button type="submit" class="secondary-button">移動</button>
+          </form>
+          <div class="column-controls">
+            <label class="width-control">
+              <span>幅:</span>
+              <input type="range" min="10" max="100" value="30" class="width-slider" />
+              <span class="width-value">30%</span>
+            </label>
+            <button type="button" class="icon-button remove-column" title="列を削除">✕</button>
+          </div>
+        </header>
+        <div class="frame-container">
+          <iframe
+            is="x-frame-bypass"
+            class="column-frame"
+            sandbox="allow-scripts allow-forms allow-same-origin allow-pointer-lock allow-popups allow-modals allow-downloads"
+          ></iframe>
+          <div class="frame-overlay" hidden>
+            <div class="overlay-content">
+              <h2 class="overlay-title">読み込み中...</h2>
+              <p class="overlay-message">ページを読み込んでいます。</p>
+              <p class="overlay-detail" hidden></p>
+              <div class="overlay-actions" hidden>
+                <button type="button" class="secondary-button overlay-action">新しいタブで開く</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </template>
+    <script type="module" src="dashboard.js"></script>
+  </body>
+</html>

--- a/MultipleWindow/dashboard.js
+++ b/MultipleWindow/dashboard.js
@@ -1,0 +1,407 @@
+import './x-frame-bypass.js';
+
+const columnsContainer = document.getElementById('columns');
+const addForm = document.getElementById('add-column-form');
+const urlInput = document.getElementById('url-input');
+const widthInput = document.getElementById('width-input');
+const columnTemplate = document.getElementById('column-template');
+
+let columnsState = [];
+const columnViews = new Map();
+let currentTabId = null;
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+const normalizeUrl = (rawUrl) => {
+  if (!rawUrl) return null;
+  let url = rawUrl.trim();
+  if (!url) return null;
+  if (!/^https?:\/\//i.test(url)) {
+    url = `https://${url}`;
+  }
+  try {
+    return new URL(url).toString();
+  } catch (error) {
+    return null;
+  }
+};
+
+const normalizeAbsoluteUrl = (rawUrl) => {
+  if (!rawUrl) return null;
+  try {
+    return new URL(rawUrl).toString();
+  } catch (error) {
+    return null;
+  }
+};
+
+const extractHostname = (rawUrl) => {
+  try {
+    const { hostname } = new URL(rawUrl);
+    return hostname || rawUrl;
+  } catch (error) {
+    return rawUrl;
+  }
+};
+
+const registerDashboard = () =>
+  new Promise((resolve) => {
+    if (!chrome?.runtime?.sendMessage) {
+      resolve(null);
+      return;
+    }
+    try {
+      chrome.runtime.sendMessage({ type: 'registerDashboard' }, (response) => {
+        if (chrome.runtime.lastError) {
+          resolve(null);
+          return;
+        }
+        const tabId = typeof response?.tabId === 'number' ? response.tabId : null;
+        currentTabId = tabId;
+        resolve(tabId);
+      });
+    } catch (error) {
+      resolve(null);
+    }
+  });
+
+const persistColumns = async () => {
+  await chrome.storage.local.set({ columns: columnsState });
+};
+
+const createId = () => {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return `col-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+};
+
+const setInputError = (input, message) => {
+  if (input && typeof input.setCustomValidity === 'function') {
+    input.setCustomValidity(message);
+    input.reportValidity();
+  }
+};
+
+const clearInputError = (input) => {
+  if (input && typeof input.setCustomValidity === 'function') {
+    input.setCustomValidity('');
+  }
+};
+
+const getColumnView = (columnId) => columnViews.get(columnId);
+
+const showLoadingOverlay = (columnId, targetUrl) => {
+  const view = getColumnView(columnId);
+  if (!view) return;
+  view.currentUrl = targetUrl ?? view.currentUrl;
+  view.overlay.hidden = false;
+  view.overlay.dataset.state = 'loading';
+  view.overlay.classList.remove('is-error');
+  view.overlayTitle.textContent = '読み込み中...';
+  view.overlayMessage.textContent = 'ページを読み込んでいます。';
+  view.overlayDetail.textContent = '';
+  view.overlayDetail.hidden = true;
+  view.overlayActions.hidden = true;
+  view.overlayAction.hidden = true;
+  if (view.addressInput) {
+    view.addressInput.classList.remove('input-error');
+    clearInputError(view.addressInput);
+  }
+};
+
+const showBlockedOverlay = (columnId, targetUrl, reason) => {
+  const view = getColumnView(columnId);
+  if (!view) return;
+  const normalizedTarget = normalizeAbsoluteUrl(targetUrl) ?? view.currentUrl ?? view.iframe?.src;
+  view.currentUrl = normalizedTarget ?? view.currentUrl;
+  const hostname = extractHostname(normalizedTarget ?? '');
+  view.overlay.hidden = false;
+  view.overlay.dataset.state = 'blocked';
+  view.overlay.classList.add('is-error');
+  view.overlayTitle.textContent = 'ページを表示できません';
+  view.overlayMessage.textContent = `${hostname} は iframe での表示を許可していない可能性があります。`;
+  if (reason) {
+    view.overlayDetail.textContent = `理由: ${reason}`;
+    view.overlayDetail.hidden = false;
+  } else {
+    view.overlayDetail.textContent = '';
+    view.overlayDetail.hidden = true;
+  }
+  view.overlayActions.hidden = false;
+  view.overlayAction.hidden = false;
+  if (view.addressInput) {
+    view.addressInput.classList.add('input-error');
+    setInputError(view.addressInput, 'このサイトは iframe での表示を許可していません');
+  }
+};
+
+const hideOverlay = (columnId) => {
+  const view = getColumnView(columnId);
+  if (!view) return;
+  if (view.overlay.dataset.state === 'blocked') {
+    return;
+  }
+  view.overlay.hidden = true;
+  view.overlay.dataset.state = 'ready';
+  view.overlay.classList.remove('is-error');
+};
+
+const setFrameSource = (columnId, targetUrl) => {
+  if (!targetUrl) return;
+  const view = getColumnView(columnId);
+  if (!view) return;
+  view.currentUrl = targetUrl;
+  showLoadingOverlay(columnId, targetUrl);
+  if (typeof view.iframe?.load === 'function') {
+    view.iframe.load(targetUrl);
+  } else {
+    view.iframe.src = targetUrl;
+  }
+};
+
+const renderColumns = () => {
+  columnsContainer.innerHTML = '';
+  columnViews.clear();
+  const fragment = document.createDocumentFragment();
+
+  columnsState.forEach((column) => {
+    const columnElement = columnTemplate.content.firstElementChild.cloneNode(true);
+    const navigationForm = columnElement.querySelector('.navigation-form');
+    const addressInput = columnElement.querySelector('.address-input');
+    const iframe = columnElement.querySelector('.column-frame');
+    const widthSlider = columnElement.querySelector('.width-slider');
+    const widthValue = columnElement.querySelector('.width-value');
+    const removeButton = columnElement.querySelector('.remove-column');
+    const overlay = columnElement.querySelector('.frame-overlay');
+    const overlayTitle = overlay.querySelector('.overlay-title');
+    const overlayMessage = overlay.querySelector('.overlay-message');
+    const overlayDetail = overlay.querySelector('.overlay-detail');
+    const overlayActions = overlay.querySelector('.overlay-actions');
+    const overlayAction = overlay.querySelector('.overlay-action');
+
+    const view = {
+      columnElement,
+      iframe,
+      overlay,
+      overlayTitle,
+      overlayMessage,
+      overlayDetail,
+      overlayActions,
+      overlayAction,
+      addressInput,
+      currentUrl: column.url
+    };
+
+    columnViews.set(column.id, view);
+
+    const effectiveWidth = column.width ?? 30;
+    columnElement.style.flex = `0 0 ${effectiveWidth}%`;
+    columnElement.style.width = `${effectiveWidth}%`;
+    widthSlider.value = effectiveWidth;
+    widthValue.textContent = `${effectiveWidth}%`;
+
+    addressInput.value = column.url;
+
+    overlayAction.addEventListener('click', () => {
+      const target = view.currentUrl ?? column.url;
+      if (!target || !chrome?.tabs?.create) {
+        return;
+      }
+      try {
+        chrome.tabs.create({ url: target });
+      } catch (error) {
+        // ignore
+      }
+    });
+
+    navigationForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const nextUrl = normalizeUrl(addressInput.value);
+      if (!nextUrl) {
+        addressInput.classList.add('input-error');
+        setInputError(addressInput, '有効なURLを入力してください');
+        return;
+      }
+      addressInput.classList.remove('input-error');
+      clearInputError(addressInput);
+      column.url = nextUrl;
+      addressInput.value = nextUrl;
+      setFrameSource(column.id, nextUrl);
+      await persistColumns();
+    });
+
+    addressInput.addEventListener('input', () => {
+      addressInput.classList.remove('input-error');
+      clearInputError(addressInput);
+    });
+
+    iframe.addEventListener('xbypass:loading', (event) => {
+      const target = normalizeAbsoluteUrl(event?.detail?.url) ?? event?.detail?.url;
+      showLoadingOverlay(column.id, target ?? column.url);
+    });
+
+    iframe.addEventListener('xbypass:load', async (event) => {
+      const loadedUrl = normalizeAbsoluteUrl(event?.detail?.url) ?? column.url;
+      let shouldPersist = false;
+      if (loadedUrl) {
+        view.currentUrl = loadedUrl;
+        const previousUrl = column.url;
+        column.url = loadedUrl;
+        addressInput.value = loadedUrl;
+        addressInput.classList.remove('input-error');
+        clearInputError(addressInput);
+        shouldPersist = loadedUrl !== previousUrl;
+      }
+      hideOverlay(column.id);
+      if (shouldPersist) {
+        await persistColumns();
+      }
+    });
+
+    iframe.addEventListener('xbypass:error', (event) => {
+      const failingUrl = normalizeAbsoluteUrl(event?.detail?.url) ?? view.currentUrl ?? column.url;
+      const reason = event?.detail?.message ?? 'ページを読み込めませんでした。';
+      showBlockedOverlay(column.id, failingUrl, reason);
+    });
+
+    iframe.addEventListener('load', () => {
+      if (iframe.getAttribute('is') !== 'x-frame-bypass') {
+        view.currentUrl = iframe?.src ?? view.currentUrl;
+      }
+      hideOverlay(column.id);
+    });
+
+    iframe.addEventListener('error', () => {
+      const failingUrl = iframe?.src || view.currentUrl || column.url;
+      showBlockedOverlay(column.id, failingUrl, 'ページを読み込めませんでした。');
+    });
+
+    widthSlider.addEventListener('input', () => {
+      const value = parseInt(widthSlider.value, 10);
+      widthValue.textContent = `${value}%`;
+      columnElement.style.flex = `0 0 ${value}%`;
+      columnElement.style.width = `${value}%`;
+    });
+
+    widthSlider.addEventListener('change', async () => {
+      const updatedWidth = parseInt(widthSlider.value, 10);
+      column.width = clamp(updatedWidth, 10, 100);
+      widthSlider.value = column.width;
+      widthValue.textContent = `${column.width}%`;
+      columnElement.style.flex = `0 0 ${column.width}%`;
+      columnElement.style.width = `${column.width}%`;
+      await persistColumns();
+    });
+
+    removeButton.addEventListener('click', async () => {
+      columnsState = columnsState.filter((item) => item.id !== column.id);
+      await persistColumns();
+      renderColumns();
+    });
+
+    setFrameSource(column.id, column.url);
+
+    fragment.appendChild(columnElement);
+  });
+
+  columnsContainer.appendChild(fragment);
+};
+
+const loadColumns = async () => {
+  const stored = await chrome.storage.local.get({ columns: [] });
+  if (Array.isArray(stored.columns)) {
+    columnsState = stored.columns;
+  } else {
+    columnsState = [];
+  }
+  renderColumns();
+};
+
+addForm.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const normalizedUrl = normalizeUrl(urlInput.value);
+  if (!normalizedUrl) {
+    urlInput.classList.add('input-error');
+    setInputError(urlInput, '有効なURLを入力してください');
+    return;
+  }
+  urlInput.classList.remove('input-error');
+  clearInputError(urlInput);
+
+  const widthValue = parseInt(widthInput.value, 10);
+  const column = {
+    id: createId(),
+    url: normalizedUrl,
+    width: clamp(Number.isFinite(widthValue) ? widthValue : 30, 10, 100)
+  };
+
+  columnsState.push(column);
+  await persistColumns();
+  renderColumns();
+
+  urlInput.value = '';
+});
+
+urlInput.addEventListener('input', () => {
+  urlInput.classList.remove('input-error');
+  clearInputError(urlInput);
+});
+
+if (chrome?.runtime?.onMessage) {
+  chrome.runtime.onMessage.addListener((message) => {
+    if (!message || message.type !== 'frameBlocked') {
+      return;
+    }
+    if (message.tabId && currentTabId && message.tabId !== currentTabId) {
+      return;
+    }
+
+    const normalizedTarget = normalizeAbsoluteUrl(message.url);
+    if (!normalizedTarget) {
+      return;
+    }
+
+    let handled = false;
+    columnViews.forEach((view, columnId) => {
+      const iframeUrl = normalizeAbsoluteUrl(view.iframe?.src);
+      const columnData = columnsState.find((item) => item.id === columnId);
+      const columnUrl = normalizeAbsoluteUrl(columnData?.url);
+      if (iframeUrl === normalizedTarget || columnUrl === normalizedTarget) {
+        showBlockedOverlay(columnId, normalizedTarget, message.reason);
+        handled = true;
+      }
+    });
+
+    if (!handled) {
+      const targetHost = extractHostname(normalizedTarget);
+      columnViews.forEach((_view, columnId) => {
+        if (handled) return;
+        const candidateView = getColumnView(columnId);
+        const iframeHost = extractHostname(candidateView?.iframe?.src ?? '');
+        if (iframeHost && iframeHost === targetHost) {
+          showBlockedOverlay(columnId, normalizedTarget, message.reason);
+          handled = true;
+        }
+      });
+    }
+  });
+}
+
+window.addEventListener('beforeunload', () => {
+  if (!chrome?.runtime?.sendMessage) {
+    return;
+  }
+  try {
+    chrome.runtime.sendMessage({ type: 'unregisterDashboard', tabId: currentTabId ?? undefined });
+  } catch (error) {
+    // ignore
+  }
+});
+
+const init = async () => {
+  await registerDashboard();
+  await loadColumns();
+};
+
+init();

--- a/MultipleWindow/manifest.json
+++ b/MultipleWindow/manifest.json
@@ -1,0 +1,15 @@
+{
+  "manifest_version": 3,
+  "name": "Multi Column Viewer",
+  "description": "View multiple URLs side by side in independently navigable columns.",
+  "version": "1.0.0",
+  "action": {
+    "default_title": "Open Multi Column Viewer"
+  },
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
+  "permissions": ["storage", "tabs", "webRequest"],
+  "host_permissions": ["<all_urls>"]
+}

--- a/MultipleWindow/x-frame-bypass.js
+++ b/MultipleWindow/x-frame-bypass.js
@@ -1,0 +1,274 @@
+const DEFAULT_PROXIES = [
+  'https://api.allorigins.win/raw?url=',
+  'https://api.codetabs.com/v1/proxy/?quest=',
+  'https://cors.isomorphic-git.org/'
+];
+
+const LOADER_HTML = `<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      html, body {
+        margin: 0;
+        height: 100%;
+        background: #fff;
+      }
+      .loader {
+        position: absolute;
+        top: calc(50% - 25px);
+        left: calc(50% - 25px);
+        width: 50px;
+        height: 50px;
+        background-color: #333;
+        border-radius: 50%;
+        animation: loader 1s infinite ease-in-out;
+      }
+      @keyframes loader {
+        0% {
+          transform: scale(0);
+        }
+        100% {
+          transform: scale(1);
+          opacity: 0;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="loader"></div>
+  </body>
+</html>`;
+
+const NAVIGATION_HELPER = `
+  <base href="__BASE_URL__">
+  <script>
+    const toAbsoluteUrl = (value) => {
+      try {
+        return new URL(value, document.baseURI).toString();
+      } catch (error) {
+        return value;
+      }
+    };
+
+    document.addEventListener('click', (event) => {
+      if (!frameElement) {
+        return;
+      }
+      const anchor = event.target?.closest('a[href]');
+      if (!anchor) {
+        return;
+      }
+      const targetAttr = anchor.getAttribute('target');
+      if (targetAttr && targetAttr.toLowerCase() === '_blank') {
+        return;
+      }
+      event.preventDefault();
+      frameElement.load(toAbsoluteUrl(anchor.href));
+    });
+
+    document.addEventListener('submit', (event) => {
+      if (!frameElement) {
+        return;
+      }
+      const form = event.target;
+      if (!(form instanceof HTMLFormElement)) {
+        return;
+      }
+      event.preventDefault();
+      const method = (form.method || 'get').toLowerCase();
+      const action = toAbsoluteUrl(form.action || document.baseURI);
+      if (method === 'post') {
+        const formData = new FormData(form);
+        frameElement.load(action, { method: 'post', body: formData });
+        return;
+      }
+      const params = new URLSearchParams(new FormData(form));
+      const url = new URL(action);
+      params.forEach((value, key) => {
+        url.searchParams.set(key, value);
+      });
+      frameElement.load(url.toString());
+    });
+  </script>
+`.trim();
+
+class XFrameBypassElement extends HTMLIFrameElement {
+  static get observedAttributes() {
+    return ['src'];
+  }
+
+  constructor() {
+    super();
+    this._currentUrl = null;
+    this._proxies = DEFAULT_PROXIES.slice();
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === 'src' && newValue) {
+      this.load(newValue);
+    }
+  }
+
+  connectedCallback() {
+    if (!this.hasAttribute('sandbox')) {
+      this.sandbox =
+        'allow-forms allow-modals allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts allow-top-navigation-by-user-activation';
+    }
+  }
+
+  set proxies(list) {
+    if (Array.isArray(list) && list.length > 0) {
+      this._proxies = list.slice();
+    }
+  }
+
+  get proxies() {
+    return this._proxies.slice();
+  }
+
+  load(url, options = {}) {
+    if (!url) {
+      return;
+    }
+    const normalizedUrl = this._normalizeUrl(url);
+    this._currentUrl = normalizedUrl;
+    this.dispatchEvent(
+      new CustomEvent('xbypass:loading', { detail: { url: normalizedUrl }, bubbles: true })
+    );
+    this.srcdoc = LOADER_HTML;
+
+    this._fetchThroughProxy(normalizedUrl, options, 0)
+      .then((response) => response.text())
+      .then((html) => {
+        const processed = this._injectHelpers(html, normalizedUrl);
+        this.srcdoc = processed;
+        this.dispatchEvent(
+          new CustomEvent('xbypass:load', { detail: { url: normalizedUrl }, bubbles: true })
+        );
+      })
+      .catch((error) => {
+        console.error('Cannot load X-Frame-Bypass:', error);
+        const message = error instanceof Error ? error.message : String(error);
+        this.srcdoc = this._renderError(normalizedUrl, message);
+        this.dispatchEvent(
+          new CustomEvent('xbypass:error', {
+            detail: { url: normalizedUrl, message },
+            bubbles: true
+          })
+        );
+      });
+  }
+
+  _normalizeUrl(url) {
+    if (/^https?:\/\//i.test(url)) {
+      return url;
+    }
+    throw new Error(`X-Frame-Bypass src ${url} does not start with http(s)://`);
+  }
+
+  _injectHelpers(html, url) {
+    if (!html) {
+      return this._renderError(url, 'Empty response from proxy');
+    }
+    const helperMarkup = NAVIGATION_HELPER.replace('__BASE_URL__', this._escapeAttribute(url));
+    let content = html;
+    if (/<head([^>]*)>/i.test(content)) {
+      content = content.replace(/<head([^>]*)>/i, (match, attrs) => `<head${attrs || ''}>\n${helperMarkup}`);
+    } else {
+      content = `<head>${helperMarkup}</head>${content}`;
+    }
+    const withoutCsp = content
+      .replace(/<meta[^>]+http-equiv=["']?content-security-policy["']?[^>]*>/gi, '')
+      .replace(/<meta[^>]+content=["'][^"']*frame-ancestors[^"']*["'][^>]*>/gi, '');
+    return withoutCsp.replace(/ crossorigin=['"][^'"]*['"]/gi, '');
+  }
+
+  _renderError(url, message) {
+    return `<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        margin: 0;
+        padding: 32px;
+        color: #222;
+        background: #fafafa;
+      }
+      h1 {
+        font-size: 18px;
+        margin-bottom: 12px;
+      }
+      p {
+        margin: 0 0 8px 0;
+        line-height: 1.4;
+      }
+      code {
+        display: inline-block;
+        padding: 2px 4px;
+        background: rgba(0,0,0,0.06);
+        border-radius: 4px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>ページを読み込めません</h1>
+    <p><strong>URL:</strong> <code>${this._escapeHtml(url)}</code></p>
+    <p><strong>理由:</strong> ${this._escapeHtml(message)}</p>
+  </body>
+</html>`;
+  }
+
+  _escapeAttribute(value) {
+    return String(value).replace(/"/g, '&quot;');
+  }
+
+  _escapeHtml(value) {
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  _fetchThroughProxy(url, options, index) {
+    const proxies = this._proxies;
+    if (!Array.isArray(proxies) || proxies.length === 0) {
+      return fetch(url, options);
+    }
+    const target = proxies[index] + encodeURIComponent(url);
+    return fetch(target, this._cloneRequestInit(options))
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`${response.status} ${response.statusText}`);
+        }
+        return response;
+      })
+      .catch((error) => {
+        if (index >= proxies.length - 1) {
+          throw error;
+        }
+        return this._fetchThroughProxy(url, options, index + 1);
+      });
+  }
+
+  _cloneRequestInit(options) {
+    if (!options) {
+      return undefined;
+    }
+    const init = { ...options };
+    if (options.body instanceof FormData) {
+      const cloned = new FormData();
+      options.body.forEach((value, key) => {
+        cloned.append(key, value);
+      });
+      init.body = cloned;
+    }
+    return init;
+  }
+}
+
+customElements.define('x-frame-bypass', XFrameBypassElement, { extends: 'iframe' });


### PR DESCRIPTION
## Summary
- register a custom x-frame-bypass iframe element that proxies requests through public CORS helpers and injects navigation handlers to avoid X-Frame-Options blocks
- wire the dashboard to use the new element, respond to custom loading/error events, and persist navigations triggered from within a column
- mark each iframe instance in the template so all columns benefit from the bypass behavior

## Testing
- not run (chrome extension UI)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690eb947ed08832bad524fa63db84503)